### PR TITLE
"params.logo" was wrong filetype

### DIFF
--- a/conf/params.config
+++ b/conf/params.config
@@ -23,7 +23,7 @@ params {
   skip_bacterial_typing = null
 
   pipeline_version = '0.5'
-  logo = "$projectDir/data/blank_logo.jpg"
+  logo = "$projectDir/data/blank_logo.png"
 
   input_type = "fastq"
 


### PR DESCRIPTION
params.config specifies "logo = <....>.jpg" but the project only contains a .png version. Upon running the pipeline, I got this error: 

```ERROR ~ Error executing process > 'NXF_LOMA:LOMA:READQC_PLOT:PLOT_READQCMETRICS (SRR29980950)'

Caused by:
  Process `NXF_LOMA:LOMA:READQC_PLOT:PLOT_READQCMETRICS (SRR29980950)` terminated with an error exit status (1)


Command executed:

  plot_readqc.py \
     --nanoplot_raw_pre SRR29980950.preqc.NanoPlot-data.tsv.gz \
     --nanoplot_raw_post SRR29980950.postqc.NanoPlot-data.tsv.gz \
     --nanostats_pre SRR29980950.preqc.NanoStats.txt \
     --nanostats_post SRR29980950.postqc.NanoStats.txt \
     --nucl_comp_pre_fw SRR29980950.preqc.fw.txt \
     --nucl_comp_pre_rv SRR29980950.preqc.rv.txt \
     --nucl_comp_post_fw SRR29980950.postqc.fw.txt \
     --nucl_comp_post_rv SRR29980950.postqc.rv.txt \
     --report_template readqc_report_template.html \
     --logo /scratch/s.2010961/loma/LOMA/data/blank_logo.jpg \
     --sample_id SRR29980950 \
     --run_id RUN01 \
     --barcode SAMN42799967 \
     --sample_type OXFORD_NANOPORE \
     --output SRR29980950.RUN01

  cat <<-END_VERSIONS > versions.yml
  "NXF_LOMA:LOMA:READQC_PLOT:PLOT_READQCMETRICS":
      plot_readqc.py: $(plot_readqc.py --version 2>&1 | tail -1 | cut -f2 -d " ")
  END_VERSIONS

Command exit status:
  1

Command output:
  (empty)

Command error:
  Traceback (most recent call last):
    File "/scratch/s.2010961/loma/LOMA/bin/plot_readqc.py", line 358, in <module>
      main()
    File "/scratch/s.2010961/loma/LOMA/bin/plot_readqc.py", line 328, in main
      sample_data = process_metadata(args.sample_id, args.run_id, args.barcode, args.sample_type, args.logo)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/scratch/s.2010961/loma/LOMA/bin/plot_readqc.py", line 30, in process_metadata
      with open(logo, "rb") as image_file:
           ^^^^^^^^^^^^^^^^
  FileNotFoundError: [Errno 2] No such file or directory: '/scratch/s.2010961/loma/LOMA/data/blank_logo.jpg'

Work dir:
  /scratch/s.2010961/loma/LOMA/work/83/76da397a24e33a9aed5ea0e6e0c5c2

Container:
  /scratch/s.2010961/.loma_singularity/quay.io-djberger-lma_img-latest.img

```

Changing the line in params.config to .png makes this step run as normal. I think this is an easy fix... 