### PR TITLE
target_species.tsv correctly referenced in params.config

### DIFF
--- a/conf/params.config
+++ b/conf/params.config
@@ -87,7 +87,7 @@ params {
 
   TAXONOMIC_PROFILING.gtdb_metadata = "$projectDir/data/gtdb_r220_metadata.tsv.gz"
   TAXONOMIC_PROFILING.dbdir = "" // (names.dmp, merged.dmp, nodes.dmp)
-  TAXONOMIC_PROFILING.target_species = "$projectDir/data/target_species.list"
+  TAXONOMIC_PROFILING.target_species = "$projectDir/data/target_species.tsv"
   PARSE_KRAKEN2HITS.min_target_reads = 1
   PARSE_KRAKEN2HITS.min_target_fraction = 0
   PARSE_CENTRIFUGERHITS.min_target_reads = 1


### PR DESCRIPTION
Another file extension fix:

PARSE_CENTRIFUGERHITS was failing because of the invalid reference to target_species.list, defined in params. I can't see anything that creates a target_species.list file, so changing the default value of params.TAXONOMIC_PROFILING.target_species to point to target_species.tsv (which does exist) appears to fix it.

Relevant .command.err...

```
Traceback (most recent call last):
  File "/scratch/s.2010961/loma/LOMA/bin/parse_taxonomic_hits.py", line 123, in <module>
    main()
  File "/scratch/s.2010961/loma/LOMA/bin/parse_taxonomic_hits.py", line 108, in main
    merged_union = process_hits(args.taxhits, args.targets, args.min_reads, args.min_frac)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/scratch/s.2010961/loma/LOMA/bin/parse_taxonomic_hits.py", line 21, in process_hits
    targets_tbl = pd.read_csv(target_list, delimiter='\t', header=None)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/pandas/io/parsers/readers.py", line 1026, in read_csv
    return _read(filepath_or_buffer, kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/pandas/io/parsers/readers.py", line 620, in _read
    parser = TextFileReader(filepath_or_buffer, **kwds)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/pandas/io/parsers/readers.py", line 1620, in __init__
    self._engine = self._make_engine(f, self.engine)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/pandas/io/parsers/readers.py", line 1880, in _make_engine
    self.handles = get_handle(
                   ^^^^^^^^^^^
  File "/opt/conda/lib/python3.12/site-packages/pandas/io/common.py", line 873, in get_handle
    handle = open(
             ^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'target_species.list'
```