### PR TITLE
TAXONOMIC_PROFILING accepts decontaminated reads

### DIFF
--- a/conf/params.config
+++ b/conf/params.config
@@ -84,6 +84,7 @@ params {
   TAXONOMIC_PROFILING.krakendb = "" // Reference Kraken2 database for taxonomic assignment (*.k2d, *.map, etc)
   TAXONOMIC_PROFILING.centrifugerdb = "" // Reference Centrifuger database for taxonomic assignment (*.cfr)
   TAXONOMIC_PROFILING.sylphdb = "" // Reference Sylph database for taxonomic assignment (*.syldb)
+  TAXONOMIC_PROFILING.use_decontaminated_reads = null
 
   TAXONOMIC_PROFILING.gtdb_metadata = "$projectDir/data/gtdb_r220_metadata.tsv.gz"
   TAXONOMIC_PROFILING.dbdir = "" // (names.dmp, merged.dmp, nodes.dmp)

--- a/workflows/loma.nf
+++ b/workflows/loma.nf
@@ -76,7 +76,13 @@ else if (params.input_type =="fastq") {
     ch_final_report = ch_final_report.mix(READQC_PLOT.out.ch_readqc_stats)
 
     if (!params.skip_taxonomic_profiling ) {
-        TAXONOMIC_PROFILING(READ_DECONTAMINATION.out.postqc_reads)
+        if (params.TAXONOMIC_PROFILING.use_decontaminated_reads) {
+            ch_taxonomic_profiling_reads = READ_DECONTAMINATION.out.postqc_reads
+        } else {
+            ch_taxonomic_profiling_reads = READ_QC.out.qc_pass_reads
+        }
+
+        TAXONOMIC_PROFILING(ch_taxonomic_profiling_reads)
         ch_versions = ch_versions.mix(TAXONOMIC_PROFILING.out.versions)
 
         ch_final_report = ch_final_report.mix(TAXONOMIC_PROFILING.out.ch_taxreports)

--- a/workflows/loma.nf
+++ b/workflows/loma.nf
@@ -76,7 +76,7 @@ else if (params.input_type =="fastq") {
     ch_final_report = ch_final_report.mix(READQC_PLOT.out.ch_readqc_stats)
 
     if (!params.skip_taxonomic_profiling ) {
-        TAXONOMIC_PROFILING(READ_QC.out.qc_pass_reads)
+        TAXONOMIC_PROFILING(READ_DECONTAMINATION.out.postqc_reads)
         ch_versions = ch_versions.mix(TAXONOMIC_PROFILING.out.versions)
 
         ch_final_report = ch_final_report.mix(TAXONOMIC_PROFILING.out.ch_taxreports)


### PR DESCRIPTION
Hi, (it's me again)

I saw my Kraken2/Bracken reports contained a lot of Homo sapiens reads, and I think it's because TAXONOMIC_PROFILING was accepting input from the READ_QC step instead of the READ_DECONTAMINATION step.

Please scrutinize what I'm doing, because I'm quite new to Nextflow development. I think this is a fix!

![image](https://github.com/user-attachments/assets/dd25c849-ddc7-43de-b001-3a0516aea165)

